### PR TITLE
Fixed a bug in QunToken.toknenize(std::string)

### DIFF
--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -18,7 +18,7 @@ const std::string HELP_STR = "Usage:\n"
                              "\t-f FORMAT\tDefine output format. Valid formats: xml, json, tsv and raw. Default format: tsv.\n"
                              "\t-V\t\tDisplay version number and exit.\n"
                              "\t-h\t\tDisplay this help and exit";
-const std::string VERSION  = "quntoken 1.3.0";
+const std::string VERSION  = "quntoken 1.3.1";
 
 
 int main(int argc, char** argv) {

--- a/src/cpp/quntoken.cpp
+++ b/src/cpp/quntoken.cpp
@@ -30,6 +30,7 @@ QunToken::QunToken(const std::string& format,
 }
 
 std::string QunToken::tokenize(const std::string& input) {
+    inss.clear();
     inss.str(input);
     outss.str("");
     tokenize(inss, outss);


### PR DESCRIPTION
It only worked for the first time after creating the object due to the input string stream's EOF big being set.